### PR TITLE
Fix ParamParser range parsing

### DIFF
--- a/lib/cafe_car/param_parser.rb
+++ b/lib/cafe_car/param_parser.rb
@@ -31,7 +31,11 @@ class CafeCar::ParamParser
     when /[{}\[\]]/ then value(JSON.parse(v))
     when /,/        then value(v.split(','))
     when /^(.*?)\.\.(\.?)(.*)$/
-      Range.new(value($1), value($3), $2.present?)
+      begin
+        Range.new(value($1), value($3), $2.present?)
+      rescue ArgumentError
+        v
+      end
     when /^\$(\w+)\.(\w+)$/
       # TODO: make less scary
       $1.constantize.arel_table[$2]

--- a/test/cafe_car/param_parser_test.rb
+++ b/test/cafe_car/param_parser_test.rb
@@ -1,9 +1,16 @@
-require 'minitest/autorun'
+require "test_helper"
 
 module CafeCar
-  class ParamParserTest < Minitest::Test
-    def test
-      skip 'Not implemented'
+  class ParamParserTest < ActiveSupport::TestCase
+    test "handles invalid range string" do
+      parser = ParamParser.new({"a" => "1..2..3"})
+      assert_equal "1..2..3", parser.parsed[:a]
+    end
+
+    test "parses valid ranges" do
+      parser = ParamParser.new({"a" => "1..2", "b" => "3...5"})
+      assert_equal "1".."2", parser.parsed[:a]
+      assert_equal "3"..."5", parser.parsed[:b]
     end
   end
 end


### PR DESCRIPTION
## Summary
- handle invalid range strings in `ParamParser`
- add ParamParser tests

## Testing
- `bundle exec rake app:test`

------
https://chatgpt.com/codex/tasks/task_e_686d2f3b5e708323aaa99567b0a59d5c