### PR TITLE
Fix test failures: minitest compat, namespace routing, presenter bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "minitest", "~> 5.0"
 gem "mutex_m"
 
 gem "bcrypt"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,8 +216,7 @@ GEM
       logger
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (6.0.1)
-      prism (~> 1.5)
+    minitest (5.27.0)
     mutex_m (0.3.0)
     net-imap (0.5.12)
       date
@@ -258,7 +257,7 @@ GEM
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.6.0)
+    prism (1.9.0)
     propshaft (1.3.1)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -434,6 +433,7 @@ DEPENDENCIES
   faker
   hotwire-livereload
   image_processing (~> 1.13)
+  minitest (~> 5.0)
   mutex_m
   paper_trail
   puma

--- a/lib/cafe_car/controller.rb
+++ b/lib/cafe_car/controller.rb
@@ -51,7 +51,7 @@ module CafeCar
       helper_method :action, :scope, :view
 
       helper Helpers
-      delegate :present, :href_for, to: :helpers
+      delegate :present, :href_for, :namespace, to: :helpers
 
       after_action :verify_authorized, :verify_policy_scoped
     end
@@ -74,6 +74,10 @@ module CafeCar
     def destroy
       run_callbacks(:destroy) { object.destroy! }
       respond_with object
+    end
+
+    def respond_with(*resources, **options, &block)
+      super(*namespace, *resources, **options, &block)
     end
 
     private

--- a/test/dummy/app/presenters/invoice_presenter.rb
+++ b/test/dummy/app/presenters/invoice_presenter.rb
@@ -1,6 +1,6 @@
 class InvoicePresenter < CafeCar::Presenter
   show :total, as: :currency
-  show :number, -> { "#%03d" % _1.object }
+  show :number, -> { "#%03d" % _1 }
 
   def title = show(:number)
 end


### PR DESCRIPTION
## Summary
- Pin minitest to ~> 5.0 — minitest 6.0 changed `Runnable#run` signature, breaking Rails 8.1.1's test runner (tests silently returned 0 runs)
- Prepend controller namespace in `respond_with` so namespaced controllers (e.g. `Admin::ClientsController`) generate correct redirect URLs like `admin_client_url`
- Fix `InvoicePresenter` lambda that called `.object` on a raw Integer value

## Test plan
- [x] `bin/rails test` — 18 runs, 62 assertions, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)